### PR TITLE
Updating pubchem references in libChebi tests

### DIFF
--- a/src/test/java/uk/ac/manchester/libchebi/ReferenceParserTest.java
+++ b/src/test/java/uk/ac/manchester/libchebi/ReferenceParserTest.java
@@ -120,7 +120,7 @@ public class ReferenceParserTest
 	public void getReferencesThreeTokens() throws IOException
 	{
 		final int id = 8;
-		final Reference reference = new Reference( "49658669", "PubChem" ); //$NON-NLS-1$ //$NON-NLS-2$
+		final Reference reference = new Reference( "SID: 49658669", "PubChem" ); //$NON-NLS-1$ //$NON-NLS-2$
 		Assert.assertTrue( ReferenceParser.getInstance().getReferences( new int[] { id } ).contains( reference ) );
 	}
 
@@ -144,7 +144,7 @@ public class ReferenceParserTest
 	public void getReferencesThreeTokensNegativeReferenceDbName() throws IOException
 	{
 		final int id = 8;
-		final Reference reference = new Reference( "49658669", "Random db name" ); //$NON-NLS-1$ //$NON-NLS-2$
+		final Reference reference = new Reference( "SID: 49658669", "Random db name" ); //$NON-NLS-1$ //$NON-NLS-2$
 		Assert.assertFalse( ReferenceParser.getInstance().getReferences( new int[] { id } ).contains( reference ) );
 	}
 }


### PR DESCRIPTION
ChEBI has changed the reference IDs for PubChem introducing the SID and CID prefixes. I've updated the ReferenceParserTest accordingly.